### PR TITLE
fix cost function and add comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 __pycache__/
 uv.lock.venv./
 .venv/
+improvements.md
+bliply.egg-info/
+venv/

--- a/config/providers.json
+++ b/config/providers.json
@@ -10,7 +10,8 @@
         "name": "QuickNode",
         "limit_rps": 10,
         "limit_monthly": 80000000,
-        "priority": 1
+        "priority": 1,
+        "pricing_model": "credit"
     },
     {
         "name": "Chainstack",

--- a/core/quota_manager.py
+++ b/core/quota_manager.py
@@ -2,6 +2,8 @@ import json
 import os
 from typing import Dict
 
+# basically maintain a usage_counters.json file where we track CUs/credits/num_requests for each provider
+# and use it to implement the spillover strategy
 class QuotaManager:
     def __init__(self, data_file: str = "data/usage_counters.json"):
         self.data_file = data_file

--- a/core/rate_limiter.py
+++ b/core/rate_limiter.py
@@ -1,6 +1,7 @@
 import time
 from collections import defaultdict, deque
 
+# keep sliding window of 1 second, remove all requests older than 1 sec, and check if the number of requests(in last one second) is greater than limit_rps. if yes then this is signal to move onto the next provider
 class RateLimiter:
     def __init__(self, window_size_seconds: int = 1):
         self.window_size = window_size_seconds

--- a/core/router.py
+++ b/core/router.py
@@ -1,6 +1,5 @@
 from typing import Dict, Any, List, Optional
 import time
-import asyncio
 from typing import NamedTuple
 
 from services.request_parser import RequestParser
@@ -44,6 +43,9 @@ class RPCOptimizer:
             request_id = parsed_request["id"]
             
             # 1. Get List of Potential Providers (Filtered by Quota only first)
+            # this will return those providers whose MONTHLY quota hasnt been exceeded - and in the list returned providers will be sorted in 2 ways : 
+            # 1. Priority (ascending)
+            # 2. Latency (ascending)
             potential_providers = self._get_potential_providers(method)
             
             if not potential_providers:
@@ -61,7 +63,8 @@ class RPCOptimizer:
                 if self.rate_limiter.is_allowed(p.name, p.limit_rps):
                     best_provider = p
                     break
-            
+
+            # the following point is expected to be hit very rarely because the paid plan usually has a high RPS limit
             if not best_provider:
                  return self.response_handler.build_error_response(
                     error_message="All eligible providers are rate limited",

--- a/providers/base.py
+++ b/providers/base.py
@@ -19,15 +19,13 @@ class RPCProvider:
         self.metrics = MetricsStore()
 
     def get_cost(self, method: str) -> int:
-        """
-        Calculate the cost of the request in 'units' (requests or CUs).
-        """
         if self.pricing_model == "cu":
             from config.compute_units import ALCHEMY_COMPUTE_UNITS
-            # Default to 26 (eth_call cost) if unknown, to be safe? Or 10?
-            # Using 10 as a safe default for read ops
             return ALCHEMY_COMPUTE_UNITS.get(method, 10)
-        return 1
+        elif self.pricing_model == "credit":
+            from config.compute_units import QUICKNODE_CREDITS
+            return QUICKNODE_CREDITS.get(method, QUICKNODE_CREDITS.get('default', 20))
+        return 1  # Flat pricing (Chainstack)
 
     def price_per_call(self, method: str = None) -> float:
         return 0.0


### PR DESCRIPTION
## 🐛 Fix: Add QuickNode Credit Calculation to get_cost() Method

### Problem
The get_cost() method in providers/base.py was only handling Alchemy's compute unit (CU) pricing model, causing QuickNode requests to be incorrectly counted as **1 credit** instead of the actual cost (20 credits default, 40 for `trace_call`).

This resulted in inaccurate quota tracking for QuickNode, potentially exhausting the free tier much faster than expected.

### Solution
Extended get_cost() to handle QuickNode's credit-based pricing model:

```python
def get_cost(self, method: str) -> int:
    if self.pricing_model == "cu":
        from config.compute_units import ALCHEMY_COMPUTE_UNITS
        return ALCHEMY_COMPUTE_UNITS.get(method, 10)
    elif self.pricing_model == "credit":
        from config.compute_units import QUICKNODE_CREDITS
        return QUICKNODE_CREDITS.get(method, QUICKNODE_CREDITS.get('default', 20))
    return 1  # Flat pricing (Chainstack)